### PR TITLE
Add consecutive_string_generator utility function and refactor player name generation

### DIFF
--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -1,5 +1,9 @@
+import pytest
 from pytest_mock import MockerFixture
-from werewolf.utils.utils import instant_decoration
+from werewolf.utils.utils import (
+    instant_decoration,
+    consecutive_string_generator,
+)
 
 
 class EchoNameCls:
@@ -31,3 +35,21 @@ def test_instant_decoration(mocker: MockerFixture) -> None:
             assert obj.echo_name() == f'{obj.name}{footer}'
     for obj in objs:
         assert obj.echo_name() == obj.name
+
+
+@pytest.mark.parametrize(
+    'prefix, start, step, n, expected',
+    [
+        ('a', 0, 1, 3, ['a0', 'a1', 'a2']),
+        ('b', 1, 2, 4, ['b1', 'b3', 'b5', 'b7']),
+    ]
+)
+def test_consecutive_string_generator(
+    prefix: str,
+    start: int,
+    step: int,
+    n: int,
+    expected: list[str],
+) -> None:
+    gen = consecutive_string_generator(prefix, start, step)
+    assert [p for _, p in zip(range(n), gen)] == expected

--- a/werewolf/const.py
+++ b/werewolf/const.py
@@ -5,6 +5,8 @@ DEFAULT_MODEL: str = 'gpt-4o-mini'
 DAYTIME_DISCUSSION_MANAGER_NAME: str = 'DiscussionManager(Daytime)'
 NIGHTTIME_DISCUSSION_MANAGER_NAME: str = 'DiscussionManager(Nighttime)'
 
+PREFIX_PLAYER_NAME: str = 'Player'
+
 
 class ESpeakerSelectionMethod(Enum):
     auto: str = 'auto'

--- a/werewolf/game_master/default_game_master.py
+++ b/werewolf/game_master/default_game_master.py
@@ -15,13 +15,17 @@ from ..const import (
     ERole,
     EStatus,
     DAYTIME_DISCUSSION_MANAGER_NAME,
-    NIGHTTIME_DISCUSSION_MANAGER_NAME
+    NIGHTTIME_DISCUSSION_MANAGER_NAME,
+    PREFIX_PLAYER_NAME,
 )
 from ..config import GameConfig
 from ..game_player.base import BaseWerewolfPlayer
 from ..utils.autogen_utils import just1turn
 from ..utils.openai import create_chat_openai_model
-from ..utils.utils import instant_decoration
+from ..utils.utils import (
+    consecutive_string_generator,
+    instant_decoration,
+)
 
 
 class DefaultGameMaster(BaseGameMaster):
@@ -127,16 +131,19 @@ class DefaultGameMaster(BaseGameMaster):
         human_index = random.randint(0, n_players - 1) if include_human else None  # noqa
         # generate players
         self.players = {
-            f'Player{i}': BaseWerewolfPlayer.instantiate(
+            name: BaseWerewolfPlayer.instantiate(
                 role,
-                name=f'Player{i}',
+                name=name,
                 # Need to notify the player's name in the system message  # noqa
-                system_message=f'You are "Player{i}"',
+                system_message=f'You are "{i}"',
                 llm_config=self.llm_config,
                 default_auto_reply=None,
                 human_input_mode='ALWAYS' if i == human_index else 'NEVER',
             )
-            for i, role in enumerate(roles)
+            for i, (name, role) in enumerate(zip(
+                consecutive_string_generator(prefix=PREFIX_PLAYER_NAME),
+                roles,
+            ))
         }
         # initiate chat
         for player in self.players.values():

--- a/werewolf/utils/utils.py
+++ b/werewolf/utils/utils.py
@@ -29,3 +29,21 @@ def instant_decoration(
     yield
     for obj, method in zip(objs, original_methods):
         setattr(obj, name, method)
+
+
+def consecutive_string_generator(
+    prefix: str,
+    start: int = 0,
+    step: int = 1,
+) -> Generator[str, None, None]:
+    """a generator to generate strings with a prefix and a number.
+
+    Args:
+        prefix (str): prefix of the string
+        start (int, optional): start number. Defaults to 0.
+        step (int, optional): step of the number. Defaults to 1.
+    """
+    idx = start
+    while True:
+        yield f'{prefix}{idx}'
+        idx += step


### PR DESCRIPTION
This pull request adds a new utility function called `consecutive_string_generator` that generates strings with a prefix and a number. It is used to refactor the player name generation in the `DefaultGameMaster` class. The function takes a prefix, start number, and step as arguments and returns a generator that yields consecutive strings with the specified prefix and number. The player name generation in the `DefaultGameMaster` class now uses this utility function to generate player names with the prefix "Player" followed by a number. This improves the readability and maintainability of the code.