### PR TITLE
Add jinja2 dependency to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dev = [
     "pytest>=8.3.2",
     "pytest-cov>=5.0.0",
     "pytest-mock>=3.14.0",
+    "jinja2>=3.1.4",
 ]
 
 [tool.uv]


### PR DESCRIPTION
This pull request adds the jinja2 dependency to the pyproject.toml file.

Patch for #18 