### PR TITLE
Ignore flaml==2.3.0 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
     "pytest-cov>=5.0.0",
     "pytest-mock>=3.14.0",
     "jinja2>=3.1.4",
+    "flaml!=2.3.0",        # patch for #28
 ]
 
 [tool.uv]


### PR DESCRIPTION
This pull request includes a patch that ignores the version 2.3.0 of flaml in the pyproject.toml file. This patch is made to address issue #28.