### PR TITLE
Enable overriding of environment variables in dotenv loading

### DIFF
--- a/werewolf/main.py
+++ b/werewolf/main.py
@@ -54,7 +54,7 @@ def main(
         import random
         random.seed(seed)
 
-    load_dotenv(),
+    load_dotenv(override=True)
     if os.environ.get('OPENAI_API_KEY') is None:
         raise ValueError('You must set OPENAI_API_KEY in your environment variables or .env file.')  # noqa
 


### PR DESCRIPTION
Allow the loading of environment variables from a .env file to override existing environment variables by setting the `override` parameter to true in the `load_dotenv` function.

This pull request attempts to solve the problem of values set in .env not being reflected.