### PR TITLE
[feat] update the list of available models

### DIFF
--- a/werewolf/const.py
+++ b/werewolf/const.py
@@ -52,25 +52,40 @@ class EChatService(Enum):
 
 
 MODEL_SERVICE_MAP: dict[str, EChatService] = {
+    # ref. https://platform.openai.com/docs/pricing
+    'gpt-4o': EChatService.OpenAI,
+    'gpt-4o-mini': EChatService.OpenAI,
+    'o1': EChatService.OpenAI,  # NOTE: it may be too expensive # TODO: fix a problem that logs like `params={'messages': ...` are displayed  # noqa: E501
+    'o3-mini': EChatService.OpenAI,  # TODO: fix a problem that 'WARNING:autogen.oai.client:Model o3-mini-2025-01-31 is not found.' is displayed  # noqa: E501
+    'o1-mini': EChatService.OpenAI,  # TODO: fix a problem that logs like `params={'messages': ...` are displayed  # noqa: E501
     'gpt-3.5-turbo': EChatService.OpenAI,
     'gpt-4': EChatService.OpenAI,
     'gpt-4-turbo': EChatService.OpenAI,
-    'gpt-4o': EChatService.OpenAI,
-    'gpt-4o-mini': EChatService.OpenAI,
+    # ref. https://ai.google.dev/gemini-api/docs/models
+    # 'gemini-2.5-pro-preview-03-25': EChatService.Google,
+    'gemini-2.0-flash': EChatService.Google,
+    'gemini-2.0-flash-lite': EChatService.Google,
     'gemini-1.5-flash': EChatService.Google,
-    "gemini-pro-vision": EChatService.Google,
-    'gemini-pro': EChatService.Google,
-    'gemma2-9b-it': EChatService.Groq,
-    'gemma2-7b-it': EChatService.Groq,
-    'llama3-groq-70b-8192-tool-use-preview': EChatService.Groq,
-    'llama3-groq-8b-8192-tool-use-preview': EChatService.Groq,
-    'llama-3.1-70b-versatile': EChatService.Groq,
+    'gemini-1.5-flash-8b': EChatService.Google,
+    'gemini-1.5-pro': EChatService.Google,
+    # TODO: add gemma series
+    # ref. https://groq.com/pricing/
+    'qwen-2.5-32b': EChatService.Groq,
+    'qwen-2.5-coder-32b': EChatService.Groq,
+    'qwen-qwq-32b': EChatService.Groq,
+    'deepseek-r1-distill-qwen-32b': EChatService.Groq,
+    'deepseek-r1-distill-llama-70b': EChatService.Groq,
+    'gemma2-9b-it': EChatService.Groq,  # TODO: the name is too similar to Google's one.  # noqa: E501
     'llama-3.1-8b-instant': EChatService.Groq,
-    'llama-guard-3-8b': EChatService.Groq,
-    'llava-v1.5-7b-4096-preview': EChatService.Groq,
+    'llama-3.2-1b-preview': EChatService.Groq,
+    'llama-3.2-3b-preview': EChatService.Groq,
+    'llama-3.3-70b-specdec': EChatService.Groq,
+    'llama-3.3-70b-versatile': EChatService.Groq,
     'llama3-70b-8192': EChatService.Groq,
     'llama3-8b-8192': EChatService.Groq,
-    'mixtral-8x7b-32768': EChatService.Groq,
+    'meta-llama/llama-4-maverick-17b-128e-instruct': EChatService.Groq,
+    'meta-llama/llama-4-scout-17b-16e-instruct': EChatService.Groq,
+    'mistral-saba-24b': EChatService.Groq,
 }
 VALID_MODELS: tuple[str, ...] = tuple(MODEL_SERVICE_MAP.keys())
 SERVICE_APIKEY_ENVVAR_MAP: dict[EChatService, str] = {

--- a/werewolf/main.py
+++ b/werewolf/main.py
@@ -54,7 +54,7 @@ def main(
         import random
         random.seed(seed)
 
-    load_dotenv(),
+    load_dotenv(override=True)
     if os.environ.get('OPENAI_API_KEY') is None:
         raise ValueError('You must set OPENAI_API_KEY in your environment variables or .env file.')  # noqa
 


### PR DESCRIPTION
This pull request updates the `MODEL_SERVICE_MAP` dictionary in the `werewolf/const.py` file to include new models and remove outdated ones. The changes ensure that the mapping of model names to their respective services is current and accurate.

### Updates to model-service mapping:

* Added new models under OpenAI, Google, and Groq services, including `gpt-4o`, `gpt-4o-mini`, `o1`, `o3-mini`, `o1-mini`, `gemini-2.0-flash`, `gemini-2.0-flash-lite`, `gemini-1.5-flash-8b`, `gemini-1.5-pro`, `qwen-2.5-32b`, `qwen-2.5-coder-32b`, `qwen-qwq-32b`, `deepseek-r1-distill-qwen-32b`, `deepseek-r1-distill-llama-70b`, `llama-3.2-1b-preview`, `llama-3.2-3b-preview`, `llama-3.3-70b-specdec`, `llama-3.3-70b-versatile`, `meta-llama/llama-4-maverick-17b-128e-instruct`, `meta-llama/llama-4-scout-17b-16e-instruct`, and `mistral-saba-24b`.